### PR TITLE
Allow DB connection code to work on Cloud Foundry.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,11 @@
 venv-projectmonitor/*
 venv-project-monitor/*
 venv-my-project/*
+vendor/*
+*.pyc
+local_settings.py
+
+# Cloud Foundry files
+runtime.txt
+.cfignore
+manifest.yml

--- a/projmon/__init__.py
+++ b/projmon/__init__.py
@@ -29,7 +29,16 @@ def index():
     with open(PROJECTS_FILE) as file:
         projects = json.load(file)
 
-    with connect(os.environ['DATABASE_URL']) as conn:
+    result = urlparse(os.environ['DATABASE_URL'])
+    connection = connect(
+        database = result.path[1:],
+        user = result.username,
+        password = result.password,
+        host = result.hostname,
+        port = result.port
+    )
+
+    with connection as conn:
         with conn.cursor(cursor_factory=DictCursor) as db:
             db.execute('''SELECT guid, success, url, updated_at, valid_readme
                           FROM statuses WHERE updated_at IS NOT NULL
@@ -89,7 +98,16 @@ def post_status(guid):
         updated_at = info.get('finished_at', info['started_at'])
         valid_readme = None
 
-        with connect(os.environ['DATABASE_URL']) as conn:
+        result = urlparse(os.environ['DATABASE_URL'])
+        connection = connect(
+            database = result.path[1:],
+            user = result.username,
+            password = result.password,
+            host = result.hostname,
+            port = result.port
+        )
+
+        with connection as conn:
             with conn.cursor(cursor_factory=DictCursor) as db:
                 db.execute('''INSERT INTO statuses
                               (guid, success, url, updated_at, valid_readme)


### PR DESCRIPTION
For some reason, our AWS RDS cannot parse the `postgres://` URI using `connect` by itself. This change allows the database connection code to work with our AWS RDS as well as the Cloud Foundry Postgres installation. It should also work with other Postgres installations that can automatically parse the URI such as the one on Heroku.

I also added some Cloud Foundry-specific files to the `.gitignore`.
